### PR TITLE
Fix mismatched size load

### DIFF
--- a/run_eval.py
+++ b/run_eval.py
@@ -60,6 +60,7 @@ class TimeMoE:
             }
             if flash_attn:
                 args['attn_implementation'] = 'flash_attention_2'
+            args.setdefault('ignore_mismatched_sizes', True)
             model = TimeMoeForPrediction.from_pretrained(
                 model_path,
                 **args,

--- a/time_moe/runner.py
+++ b/time_moe/runner.py
@@ -58,6 +58,7 @@ class TimeMoeRunner:
         else:
             if input_size is not None:
                 kwargs['input_size'] = input_size
+            kwargs.setdefault('ignore_mismatched_sizes', True)
             model = TimeMoeForPrediction.from_pretrained(model_path, **kwargs)
         return model
 


### PR DESCRIPTION
## Summary
- allow loading pretrained `TimeMoeForPrediction` with mismatched sizes in the runner
- do the same for evaluation script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850766854588326b6574da69d58c7e3