### PR TITLE
Fix multiprocessing dataset parsing

### DIFF
--- a/time_moe/datasets/general_dataset.py
+++ b/time_moe/datasets/general_dataset.py
@@ -10,25 +10,60 @@ import numpy as np
 from .ts_dataset import TimeSeriesDataset
 
 
+def _parse_line(line: str) -> int:
+    """Parse a json line and return sequence length.
+
+    This helper is defined at module scope so that it can be pickled by the
+    multiprocessing module when ``GeneralDataset`` reads files in parallel.
+    """
+    obj = json.loads(line)
+    seq = obj.get("sequence", obj)
+    return len(seq)
+
+
 class GeneralDataset(TimeSeriesDataset):
-    def __init__(self, data_path, streaming: bool = False):
+    def __init__(self, data_path, streaming: bool = False, num_workers: int = None):
         self.streaming = streaming
         self.num_tokens = None
+        if num_workers is None:
+            num_workers = os.cpu_count() or 1
+        self.num_workers = max(1, int(num_workers))
 
         if streaming and data_path.endswith('.jsonl'):
             self.data_path = data_path
             self.offsets = []
             self.seq_lens = []
             cur_offset = 0
-            with open(data_path, 'r', encoding='utf-8') as f:
-                line = f.readline()
-                while line:
-                    self.offsets.append(cur_offset)
-                    obj = json.loads(line)
-                    seq = obj.get('sequence', obj)
-                    self.seq_lens.append(len(seq))
-                    cur_offset = f.tell()
+
+            if self.num_workers > 1:
+                from multiprocessing import Pool
+                batch_lines = []
+                batch_offsets = []
+                with Pool(self.num_workers) as pool, open(data_path, 'r', encoding='utf-8') as f:
                     line = f.readline()
+                    while line:
+                        batch_offsets.append(cur_offset)
+                        batch_lines.append(line)
+                        cur_offset = f.tell()
+                        if len(batch_lines) >= 1024:
+                            lens = pool.map(_parse_line, batch_lines)
+                            self.offsets.extend(batch_offsets)
+                            self.seq_lens.extend(lens)
+                            batch_lines.clear()
+                            batch_offsets.clear()
+                        line = f.readline()
+                    if batch_lines:
+                        lens = pool.map(_parse_line, batch_lines)
+                        self.offsets.extend(batch_offsets)
+                        self.seq_lens.extend(lens)
+            else:
+                with open(data_path, 'r', encoding='utf-8') as f:
+                    line = f.readline()
+                    while line:
+                        self.offsets.append(cur_offset)
+                        self.seq_lens.append(_parse_line(line))
+                        cur_offset = f.tell()
+                        line = f.readline()
             self.data = None
         else:
             self.data = read_file_by_extension(data_path)

--- a/time_moe/datasets/time_moe_dataset.py
+++ b/time_moe/datasets/time_moe_dataset.py
@@ -34,7 +34,7 @@ class TimeMoEDataset(TimeSeriesDataset):
             if len(ds) > 0:
                 self.datasets.append(ds)
         elif GeneralDataset.is_valid_path(self.data_folder):
-            ds = GeneralDataset(self.data_folder, streaming=streaming)
+            ds = GeneralDataset(self.data_folder, streaming=streaming, num_workers=os.cpu_count())
             if len(ds) > 0:
                 self.datasets.append(ds)
         else:
@@ -43,7 +43,7 @@ class TimeMoEDataset(TimeSeriesDataset):
                 for file in files:
                     fn_path = os.path.join(root, file)
                     if file != BinaryDataset.meta_file_name and GeneralDataset.is_valid_path(fn_path):
-                        ds = GeneralDataset(fn_path, streaming=streaming)
+                        ds = GeneralDataset(fn_path, streaming=streaming, num_workers=os.cpu_count())
                         if len(ds) > 0:
                             self.datasets.append(ds)
                 for sub_folder in dirs:


### PR DESCRIPTION
## Summary
- keep CPU detection for TimeMoEDataset
- move line parser to module scope so multiprocessing works

## Testing
- `pytest -q`
- `pip install -q -r requirements.txt` *(fails: blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68507df55e0483269ef2d0818c9d841d