### PR TITLE
Add adaptive tqdm and run() function

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 import argparse
 from time_moe.runner import TimeMoeRunner
 import os
+
 os.environ["WANDB_MODE"] = "disabled"
 
 
-if __name__ == "__main__":
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--data_path",
@@ -170,7 +171,12 @@ if __name__ == "__main__":
         help="Enable streaming mode when loading dataset",
     )
 
-    args = parser.parse_args()
+    return parser
+
+
+def run(args=None):
+    parser = build_parser()
+    args = parser.parse_args(args)
 
     if args.flash_attn:
         args.attn_implementation = 'flash_attention_2'
@@ -184,7 +190,7 @@ if __name__ == "__main__":
         seed=args.seed,
     )
 
-    runner.train_model(
+    return runner.train_model(
         from_scratch=args.from_scratch,
         max_length=args.max_length,
         stride=args.stride,
@@ -220,3 +226,7 @@ if __name__ == "__main__":
         input_size=args.input_size,
         data_streaming=args.data_streaming,
     )
+
+
+if __name__ == "__main__":
+    run()

--- a/run_eval.py
+++ b/run_eval.py
@@ -8,7 +8,14 @@ import logging
 import torch
 import torch.distributed as dist
 from torch.utils.data import DistributedSampler, DataLoader
-from tqdm import tqdm
+try:
+    from IPython import get_ipython
+    if get_ipython() is not None:
+        from tqdm.notebook import tqdm
+    else:
+        from tqdm import tqdm
+except ImportError:  # pragma: no cover - fallback for minimal envs
+    from tqdm import tqdm
 
 from transformers import AutoModelForCausalLM
 

--- a/time_moe/datasets/time_moe_window_dataset.py
+++ b/time_moe/datasets/time_moe_window_dataset.py
@@ -49,7 +49,11 @@ class TimeMoEWindowDataset:
         num_seqs = len(self.dataset)
         iterator = range(num_seqs)
         try:
-            from tqdm import tqdm
+            from IPython import get_ipython
+            if get_ipython() is not None:
+                from tqdm.notebook import tqdm
+            else:
+                from tqdm import tqdm
             iterator = tqdm(iterator, total=num_seqs)
         except ImportError:
             pass
@@ -117,7 +121,11 @@ class UniversalTimeMoEWindowDataset:
             random.shuffle(iterator)
 
         try:
-            from tqdm import tqdm
+            from IPython import get_ipython
+            if get_ipython() is not None:
+                from tqdm.notebook import tqdm
+            else:
+                from tqdm import tqdm
             iterator = tqdm(iterator, total=n_seqs)
         except ImportError:
             pass

--- a/tools/prepare_data.py
+++ b/tools/prepare_data.py
@@ -8,7 +8,14 @@ setattr(np, 'NaN', np.nan)
 import pandas_ta
 from sklearn.preprocessing import MinMaxScaler
 import joblib
-from tqdm import tqdm
+try:
+    from IPython import get_ipython
+    if get_ipython() is not None:
+        from tqdm.notebook import tqdm
+    else:
+        from tqdm import tqdm
+except ImportError:  # pragma: no cover - fallback for minimal envs
+    from tqdm import tqdm
 
 # --- 1. GLOBAL CONFIGURATION ---
 DATA_DIR = "data_test"


### PR DESCRIPTION
## Summary
- make tqdm adapt between notebooks and terminals
- expose `run` callable in `main.py` for easier import

## Testing
- `python -m py_compile run_eval.py tools/prepare_data.py time_moe/datasets/time_moe_window_dataset.py main.py`
- `pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68556ad6d9b08326809ca974a45f3d36