### PR TITLE
Fix numpy compatibility

### DIFF
--- a/run_model.py
+++ b/run_model.py
@@ -1,5 +1,12 @@
 import pandas as pd
 import numpy as np
+
+# ``pandas_ta`` expects the constant ``np.NaN`` which was removed in
+# recent versions of NumPy (>=2.0).  For compatibility we recreate this
+# alias before importing ``pandas_ta``.
+if not hasattr(np, "NaN"):
+    np.NaN = np.nan
+
 import joblib
 import pandas_ta
 import torch


### PR DESCRIPTION
## Summary
- avoid ImportError when numpy>=2 drops `NaN`

## Testing
- `python run_model.py` *(fails: FileNotFoundError for scaler file)*

------
https://chatgpt.com/codex/tasks/task_e_68559c27c2a083269877a0ebc53daa49