### PR TITLE
Fix generation shape error for multi-feature input

### DIFF
--- a/time_moe/models/ts_generation_mixin.py
+++ b/time_moe/models/ts_generation_mixin.py
@@ -32,8 +32,13 @@ class TSGenerationMixin(GenerationMixin):
         input_ids = input_ids.to(self.device)
         if len(input_ids.shape) == 2:
             batch_size, cur_len = input_ids.shape
+        elif len(input_ids.shape) == 3:
+            batch_size, cur_len, _ = input_ids.shape
         else:
-            raise ValueError('Input shape must be: [batch_size, seq_len]')
+            raise ValueError(
+                'Input shape must be: [batch_size, seq_len] or '
+                '[batch_size, seq_len, input_size]'
+            )
         # init values
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()


### PR DESCRIPTION
## Summary
- handle 3D `input_ids` in `_greedy_search`

## Testing
- `python run_model.py` *(fails: FileNotFoundError: crypto_scaler.joblib)*

------
https://chatgpt.com/codex/tasks/task_e_6855b5e0d2cc8326876c9ea794c8bba8