### PR TITLE
Enable custom local checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ output = model.generate(normed_seqs, max_new_tokens=prediction_length)  # shape 
 normed_predictions = output[:, -prediction_length:]  # shape is [batch_size, 6]
 ```
 
+### Running `run_model.py`
+
+`run_model.py` provides a minimal example for local inference. By default it
+loads the checkpoint configured in the script, but you can specify your own
+checkpoint directory:
+
+```bash
+python run_model.py --checkpoint /path/to/checkpoint
+```
+
+The checkpoint path **must** exist locally because the script passes
+`local_files_only=True` when loading the model. Any custom Python files inside
+the directory (for example `ts_generation_mixin.py`) will be automatically
+imported.
+
 ### Evaluation
 
 + Prepare the benchmark datasets.


### PR DESCRIPTION
## Summary
- add SimpleScaler helper class and CLI option for specifying checkpoint path
- enforce checkpoint existence and load model only from local files
- document new `--checkpoint` option in README

## Testing
- `python run_model.py --checkpoint tmp_model` *(fails: ValueError from ts_generation_mixin, confirming local module usage)*

------
https://chatgpt.com/codex/tasks/task_e_6855b90b071c8326a9ef171ac4bb7aaf