### PR TITLE
Handle multi-dimensional predictions in inference

### DIFF
--- a/run_model.py
+++ b/run_model.py
@@ -58,9 +58,14 @@ def main(cfg: InferenceConfig):
     with torch.no_grad():
         gen = model.generate(inputs.to(model.device), max_new_tokens=cfg.prediction_length)
     preds = gen[0, -cfg.prediction_length:].cpu().numpy()
-    preds_unscaled = scaler.inverse_transform(preds)
+    preds_2d = preds.reshape(cfg.prediction_length, input_size)
+    preds_unscaled = scaler.inverse_transform(preds_2d)
 
-    print("Last prediction:", preds_unscaled[-1])
+    if input_size == 1:
+        last_pred = preds_unscaled[-1, 0]
+    else:
+        last_pred = preds_unscaled[-1].tolist()
+    print("Last prediction:", last_pred)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reshape predictions into 2‑D before inverse scaling
- print the last prediction appropriately for 1-D or multi-D outputs

## Testing
- `python -m py_compile run_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6855c44566548326a76622da2f45aef6