### PR TITLE
Allow 3‑D input tensors in _greedy_search

### DIFF
--- a/time_moe/models/ts_generation_mixin.py
+++ b/time_moe/models/ts_generation_mixin.py
@@ -30,10 +30,15 @@ class TSGenerationMixin(GenerationMixin):
     ) -> Union[GenerateNonBeamOutput, torch.Tensor]:
         input_ids_origin_device = input_ids.device
         input_ids = input_ids.to(self.device)
-        if len(input_ids.shape) == 2:
+        if input_ids.dim() == 2:
             batch_size, cur_len = input_ids.shape
+            input_ids = input_ids.unsqueeze(-1)
+        elif input_ids.dim() == 3:
+            batch_size, cur_len, _ = input_ids.shape
         else:
-            raise ValueError('Input shape must be: [batch_size, seq_len]')
+            raise ValueError(
+                "Input shape must be [batch_size, seq_len] or [batch_size, seq_len, input_size]"
+            )
         # init values
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()


### PR DESCRIPTION
## Summary
- support `[batch, seq_len, input_size]` inputs when generating greedily
- keep return shape unchanged

## Testing
- `python -m py_compile time_moe/models/ts_generation_mixin.py`
- `python -m py_compile run_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6855c8e8b64c8326a40a7337a7a36617