### PR TITLE
Fix generation input shape for multi-feature sequences

### DIFF
--- a/time_moe/models/ts_generation_mixin.py
+++ b/time_moe/models/ts_generation_mixin.py
@@ -32,8 +32,12 @@ class TSGenerationMixin(GenerationMixin):
         input_ids = input_ids.to(self.device)
         if len(input_ids.shape) == 2:
             batch_size, cur_len = input_ids.shape
+        elif len(input_ids.shape) == 3:
+            batch_size, cur_len, _ = input_ids.shape
         else:
-            raise ValueError('Input shape must be: [batch_size, seq_len]')
+            raise ValueError(
+                "Input shape must be: [batch_size, seq_len] or [batch_size, seq_len, input_size]"
+            )
         # init values
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()


### PR DESCRIPTION
## Summary
- allow `_greedy_search` to accept both 2D and 3D input tensors for multi-feature time series

## Testing
- `python -m py_compile run_model.py time_moe/models/ts_generation_mixin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e000ccd88326880db374fce7f523